### PR TITLE
[Dotenv][DebugCommang]: Ensure console commands respect `dotenv_path`

### DIFF
--- a/src/Symfony/Component/Dotenv/Command/DebugCommand.php
+++ b/src/Symfony/Component/Dotenv/Command/DebugCommand.php
@@ -50,7 +50,9 @@ final class DebugCommand extends Command
             return 1;
         }
 
-        $filePath = $this->projectDirectory.\DIRECTORY_SEPARATOR.'.env';
+        $composerFile = $this->projectDirectory . '/composer.json';
+        $config = (is_file($composerFile) ? json_decode(file_get_contents($composerFile), true) : [])['extra']['runtime'] ?? [];
+        $filePath = $this->projectDirectory.\DIRECTORY_SEPARATOR.($config['dotenv_path'] ?? '.env');
         $envFiles = $this->getEnvFiles($filePath);
         $availableFiles = array_filter($envFiles, 'is_file');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58158 
| License       | MIT

fix: ensure console commands respect `dotenv_path` setting from composer.json

- Updated logic to use the same approach as the `dotenv:dump` command for determining `dotenv_path`.